### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It requires **Python 3**. It was tested on **Python 3.7**, **3.8** and **3.9** u
 
 ## Version
 
-**1.1.7.2**
+**1.2**
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The possible choices are:
 
     C:\Test>python pressureTest.py 192.168.0.36 --nc --times 2
 
-    PayShield stress utility, version 1.1.5, by Marco S. Zuppone - msz@msz.eu - https://msz.eu
+    PayShield stress utility, version 1.2, by Marco S. Zuppone - msz@msz.eu - https://msz.eu
     To get more info about the usage invoke it with the -h option This software is open source, and it is under the Affero
     AGPL 3.0 license
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Depending on the firmware version the functionality may require a license and/or
   Please refer to the **LICENSE** file that is part of this project.
   The license is **[AGPL 3.0](https://www.gnu.org/licenses/agpl-3.0.en.html)**
   
-  Copyright(C) 2020-2021  **Marco S. Zuppone** - **msz@msz.eu** - [https://msz.eu](https://msz.eu)
+  Copyright(C) 2020-2023  **Marco S. Zuppone** - **msz@msz.eu** - [https://msz.eu](https://msz.eu)
 
 This program is free software: you can redistribute it and/or modify  
 it under the terms of the GNU Affero General Public License as  

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Use the parameters **--ecc-curve**, **--key-use** and **--key-exportability** to
 **--proto** specifies the protocol to use, **tcp**, **udp** or **tls**, if omitted the default value **tcp**
 is used.  
 If **tls** is used you might specify the path of the client key file and the certificate using the parameters
-**--keyfile** and **--crtfile**. 
+**--keyfile** and **--crtfile**.   
 No verifications are performed about the validity of certificates.
 
 **--keyfile** the path of the client key file, if is not specified the default value is **client.key**.  

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Use the parameters **--ecc-curve**, **--key-use** and **--key-exportability** to
 
 **--proto** specifies the protocol to use, **tcp**, **udp** or **tls**, if omitted the default value **tcp**
 is used.  
-If **tls** is used you might specify the path of the client key file and the certificate using the parameters **--keyfile** and **--crtfile**.
+If **tls** is used you might specify the path of the client key file and the certificate using the parameters
+**--keyfile** and **--crtfile**. 
 No verifications are performed about the validity of certificates.
 
 **--keyfile** the path of the client key file, if is not specified the default value is **client.key**.  

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Use the parameters **--ecc-curve**, **--key-use** and **--key-exportability** to
 **--proto** specifies the protocol to use, **tcp**, **udp** or **tls**, if omitted the default value **tcp**
 is used.  
 If **tls** is used you might specify the path of the client key file and the certificate using the parameters **--keyfile** and **--crtfile**.
+No verifications are performed about the validity of certificates.
 
 **--keyfile** the path of the client key file, if is not specified the default value is **client.key**.  
 It's only considered if the protocol is **tls**.

--- a/pressureTest.py
+++ b/pressureTest.py
@@ -14,7 +14,7 @@ from typing import Tuple, Dict
 from types import FunctionType
 from sys import exit  # it prevents issues if the exit() function is invoked in the executable version
 
-VERSION = "1.1.7.3"
+VERSION = "1.2"
 
 
 def decode_n0(response_to_decode: bytes, head_len: int):

--- a/pressureTest.py
+++ b/pressureTest.py
@@ -7,12 +7,12 @@ import socket
 import ssl
 import binascii
 import string
+import sys
 from struct import *
 import argparse
 from pathlib import Path
 from typing import Tuple, Dict
 from types import FunctionType
-from sys import exit  # it prevents issues if the exit() function is invoked in the executable version
 
 VERSION = "1.2"
 
@@ -942,7 +942,7 @@ if __name__ == "__main__":
             command = args.header + 'EI2' + k_len_str + '01#0000'
         elif args.key < 320 or args.key > 4096:
             print("The key length value needs to be between 320 and 4096")
-            exit()
+            sys.exit()
     elif args.nc:
         command = args.header + 'NC'
     elif args.no:
@@ -982,7 +982,7 @@ if __name__ == "__main__":
     # Now we verify if the command variable is empty. In this case we throw an error.
     if len(command) == 0:
         print("You forgot to specify the action you want to to perform on the payShield")
-        exit()
+        sys.exit()
     if args.proto == 'tls':
         # check that the cert and key files are accessible
         if not (args.keyfile.exists() and args.crtfile.exists()):
@@ -991,7 +991,7 @@ if __name__ == "__main__":
             print("You passed these values:")
             print("Certificate file:", args.crtfile)
             print("Key file:", args.keyfile)
-            exit()
+            sys.exit()
         if args.port < 2500:
             print("WARNING: generally the TLS base port is 2500. You are instead using the port ",
                   args.port, " please check that you passed the right value to the "

--- a/pressureTest.py
+++ b/pressureTest.py
@@ -750,10 +750,14 @@ def run_test(ip_addr: str, port: int, host_command: str, proto: str = "tcp", hea
             data = connection.recv(buffer_size)
         elif proto == "tls":
             # creates the TCP TLS socket
+
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            context.load_cert_chain(certfile=args.crtfile, keyfile=args.keyfile)
+            context.check_hostname = False
+            context.verify_mode=ssl.CERT_NONE
             connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            ciphers = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:AES128-GCM-SHA256:AES128-SHA256:HIGH:"
-            ciphers += "!aNULL:!eNULL:!EXPORT:!DSS:!DES:!RC4:!3DES:!MD5:!PSK"
-            ssl_sock = ssl.wrap_socket(connection, args.keyfile, args.crtfile)
+            ssl_sock=context.wrap_socket(connection,server_side=False)
+
             ssl_sock.connect((ip_addr, port))
             # send message
             ssl_sock.send(message)

--- a/pressureTest.py
+++ b/pressureTest.py
@@ -748,6 +748,7 @@ def run_test(ip_addr: str, port: int, host_command: str, proto: str = "tcp", hea
             connection.send(message)
             # receive data
             data = connection.recv(buffer_size)
+            connection.close()
         elif proto == "tls":
             # creates the TCP TLS socket
 
@@ -763,6 +764,7 @@ def run_test(ip_addr: str, port: int, host_command: str, proto: str = "tcp", hea
             ssl_sock.send(message)
             # receive data
             data = ssl_sock.recv(buffer_size)
+            ssl_sock.close()
         elif proto == "udp":
             # create the UDP socket
             connection = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)


### PR DESCRIPTION

## What's Changed

* To establish the SSL connection now we use the context.wrap_socket.  
* To ease the usability of the SSL feature no checks on the validity of the certificate chain are performed.
* Included the full **sys** library to avoid errors in the executable version when the **exit()** method was called.
* Now we explicitly call the **sys.exit()** method instead of using the built-in **exit()** one to avoid errors in the executable version.
